### PR TITLE
move ipfs prop to spec for  AdUnit and AdSlot

### DIFF
--- a/adSlot.md
+++ b/adSlot.md
@@ -4,6 +4,7 @@ Ad Slot represents Publisher ad space entity for displaying [Ad Units][Ad Unit] 
 
 ##### Spec properties (added to [ipfs] and can NOT be modified) 
 
+* `ipfs`: string, valid [ipfs] hash of spec props below
 * `type`: string, the type of the ad slot that will match [Ad Unit] `type`
 * `tags`: an array of [TargetingTag], meant for discovery between publishers/advertisers
 * `owner`: user address from the session
@@ -11,7 +12,6 @@ Ad Slot represents Publisher ad space entity for displaying [Ad Units][Ad Unit] 
 
 ##### Non spec properties (not added to ipfs and CAN be modified*)
 
-* `ipfs`: string, valid [ipfs] hash of spec props *can NOT be modified. Unit should be 
 * `title`: string, the name of the unit used in platform UI
 * `description`: string, arbitrary text used in platform UI
 * `fallbackMediaUrl`: string, a URL to the resource (usually PNG); must use the `ipfs://` protocol, to guarantee data immutability. It will be displayed int the ad slot space if there are no active campaigns for that slot

--- a/campaignSpec.md
+++ b/campaignSpec.md
@@ -36,6 +36,7 @@ Example: `{ "version": "1.0.0-alpha",  "body": "..." }`
 
 ##### Spec properties (added to [ipfs] and can NOT be modified) 
 
+* `ipfs`: string, valid [ipfs] hash of spec props below
 * `type`: string, the type of the ad unit; currently, possible values are: `legacy_250x250`, `legacy_468x60`, `legacy_336x280`, `legacy_728x90`, `legacy_120x600`, `legacy_160x600` see [IAB ad unit guidelines](https://www.soflaweb.com/standard-banner-sizes-iab-ad-unit-guidelines/) and `iab_flex_{adUnitName}` (see [IAB's new ad portfolio](https://www.iab.com/newadportfolio/) and [PDF](https://www.iab.com/wp-content/uploads/2017/08/IABNewAdPortfolio_FINAL_2017.pdf))
 * `mediaUrl`: string, a URL to the resource (usually PNG); must use the `ipfs://` protocol, to guarantee data immutability
 * `mediaMime`: string, MIME type of the media, possible values at the moment are: `image/jpeg`, `image/png`
@@ -45,9 +46,8 @@ Example: `{ "version": "1.0.0-alpha",  "body": "..." }`
 * `owner`: user address from the session
 * `created`: number, UTC timestamp in milliseconds, used as nonce for escaping duplicated spec [ipfs] hashes
 
-##### Non spec properties (not added to ipfs and CAN be modified*)
+##### Non spec properties (not added to ipfs and CAN be modified)
 
-* `ipfs`: string, valid [ipfs] hash of spec props *can NOT be modified. Unit should be accessible by this [ipfs] hash
 * `title`: string, the name of the unit used in platform UI
 * `description`: string, arbitrary text used in platform UI
 * `archived`: boolean, user can change it - used for filtering in platform UI


### PR DESCRIPTION
I don't know what I was thinking putting ipfs prop out of spec. We need this as `id` in the adex-market also it is fast way to verify  slots and units data.